### PR TITLE
chore: change HC region for tests

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -23,7 +23,7 @@ maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.17.0, Apache-2.0, approved, #13669
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.17.0, Apache-2.0, approved, #14161
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.14.2, Apache-2.0, approved, #8597
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.17.0, Apache-2.0, restricted, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.17.0, Apache-2.0, approved, #15117
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.2, Apache-2.0, approved, #4699
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.1, Apache-2.0, approved, #11853

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -1,5 +1,5 @@
 variable "region" {
-  default = "ap-southeast-1"
+  default = "eu-west-101"
 }
 
 variable "instance_name" {


### PR DESCRIPTION
## What this PR changes/adds

Change HC-region in terraform scripts to "eu-west-101"

## Why it does that

Access policies changed for this repo. For authentication of Terraform scripts, which are used for GitHub actinons and testing purposes, the new region is required.