### PR TITLE
ci: disable GaussDB integration tests

### DIFF
--- a/.github/workflows/gaussdb-tests.yaml
+++ b/.github/workflows/gaussdb-tests.yaml
@@ -2,8 +2,6 @@
 name: "Run GaussDB Tests"
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   secret-presence:


### PR DESCRIPTION
## What this PR changes/adds

Disable GaussDB integration tests to run every day. 

## Why it does that

Not necessary to run it every day. Instead start them manually whenever there is a release. 

## Further notes

NA

## Linked Issue(s)

NA

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
