### PR TITLE
ci: add permissions for writing to pull requests

### DIFF
--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   add-comment:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/first-interaction@v1
         with:


### PR DESCRIPTION
## What this PR changes/adds

Fixes the error with first interaction github action. 

## Why it does that

Currently the failure seem to be due to missing permissions. 

## Further notes

NA

## Linked Issue(s)

NA
