### PR TITLE
ci: Added required 'packages: write' permission to Publish Snapshot workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,24 @@
+name: Nightly Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Semantic Version string to use for this nightly build. It should ends with `-SNAPSHOT`. If not, please take a look at the release workflow.
+        required: false
+  schedule:
+    - cron: "0 3 * * *" # run at 03:00 UTC
+
+jobs:
+
+  Run-Tests:
+    uses: ./.github/workflows/verify.yaml
+    secrets: inherit
+
+  Publish:
+    if: always()
+    needs: [ Run-Tests ]
+    uses: eclipse-edc/.github/.github/workflows/technology-nightly.yml@main
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}

--- a/.github/workflows/trigger_snapshot.yml
+++ b/.github/workflows/trigger_snapshot.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  packages: write
+  contents: read
 
 jobs:
   Publish-Snapshot:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,6 +1,12 @@
 name: Run Tests
 
 on:
+  workflow_call:
+    inputs:
+      skip-dependency-check:
+        description: 'Skip the Dependency-Check job'
+        required: false
+        default: 'false'
   workflow_dispatch:
   push:
     branches: [ main, release/*, bugfix/* ]

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -31,6 +31,7 @@ jobs:
         run: ./gradlew checkstyleMain checkstyleTest
 
   Dependency-Check:
+    if: ${{ inputs.skip-dependency-check != 'true' }}
     uses: eclipse-edc/.github/.github/workflows/dependency-check.yml@main
     secrets: inherit
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -37,7 +37,6 @@ jobs:
         run: ./gradlew checkstyleMain checkstyleTest
 
   Dependency-Check:
-    if: ${{ inputs.skip-dependency-check != 'true' }}
     uses: eclipse-edc/.github/.github/workflows/dependency-check.yml@main
     secrets: inherit
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,11 +2,6 @@ name: Run Tests
 
 on:
   workflow_call:
-    inputs:
-      skip-dependency-check:
-        description: 'Skip the Dependency-Check job'
-        required: false
-        default: 'false'
   workflow_dispatch:
   push:
     branches: [ main, release/*, bugfix/* ]


### PR DESCRIPTION
## What this PR changes/adds

_Gives the "packages: write" permission to trigger_snapshot.yml ._

## Why it does that

_Publish Snapshot Build workflow throws the following "The workflow is not valid. .github/workflows/trigger_snapshot.yml (Line: 11, Col: 3): Error calling workflow 'eclipse-edc/.github/.github/workflows/publish-snapshot.yml@main'. The nested job 'Publish-Snapshot' is requesting 'packages: write', but is only allowed 'packages: read'." message so relevant  permission is given in the workflow file._

## Linked Issue(s)

Closes # <-- _https://github.com/eclipse-edc/Technology-HuaweiCloud/issues/66_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
