### PR TITLE
ci: Added required 'packages: write' permission to Publish Snapshot workflow

### DIFF
--- a/.github/workflows/trigger_snapshot.yml
+++ b/.github/workflows/trigger_snapshot.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  packages: write
+  contents: read
 
 jobs:
   Publish-Snapshot:


### PR DESCRIPTION
## What this PR changes/adds

_Gives the "packages: write" permission to trigger_snapshot.yml ._

## Why it does that

_Publish Snapshot Build workflow throws the following "The workflow is not valid. .github/workflows/trigger_snapshot.yml (Line: 11, Col: 3): Error calling workflow 'eclipse-edc/.github/.github/workflows/publish-snapshot.yml@main'. The nested job 'Publish-Snapshot' is requesting 'packages: write', but is only allowed 'packages: read'." message so relevant permission is given in the workflow file.._


## Linked Issue(s)

Closes # <-- _https://github.com/eclipse-edc/Technology-HuaweiCloud/issues/66_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
