### PR TITLE
chore(ci): update Discord webhook secret names

### DIFF
--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -15,7 +15,7 @@ jobs:
         uses: tsickert/discord-webhook@v6.0.0
         if: ${{ (github.event_name == 'discussion') }}
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          webhook-url: ${{ secrets.DISCORD_GITHUB_WEBHOOK }}
           avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
           embed-author-name: ${{ github.event.sender.login }}
           embed-author-url: ${{ github.event.sender.html_url }}
@@ -28,7 +28,7 @@ jobs:
         uses: tsickert/discord-webhook@v6.0.0
         if: ${{ (github.event_name == 'issues') }}
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          webhook-url: ${{ secrets.DISCORD_GITHUB_WEBHOOK }}
           avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
           embed-author-name: ${{ github.event.sender.login }}
           embed-author-url: ${{ github.event.sender.html_url }}
@@ -41,7 +41,7 @@ jobs:
         uses: tsickert/discord-webhook@v6.0.0
         if: ${{ (github.event_name == 'pull_request_target') }}
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          webhook-url: ${{ secrets.DISCORD_GITHUB_WEBHOOK }}
           avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
           embed-author-name: ${{ github.event.sender.login }}
           embed-author-url: ${{ github.event.sender.html_url }}


### PR DESCRIPTION
## What this PR changes/adds

When a new PR, issue or discussion is opened, a Discord notification is sent. This PR corrects the name of the variable to use the correct secret so that the Discord webhook works.

## Why it does that

Currently, Discord notification don't work.

## Linked Issue(s)

Closes #70 
