### PR TITLE
feat: 69 feat bump version

### DIFF
--- a/e2e-tests/build.gradle.kts
+++ b/e2e-tests/build.gradle.kts
@@ -18,6 +18,8 @@ plugins {
 
 dependencies {
     testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.lib.transform)
+    testImplementation(libs.edc.transform.dpf.signaling)
     testImplementation(testFixtures(libs.edc.testfixtures.managementapi))
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)

--- a/e2e-tests/src/test/java/com/huawei/cloud/fixtures/HuaweiParticipant.java
+++ b/e2e-tests/src/test/java/com/huawei/cloud/fixtures/HuaweiParticipant.java
@@ -15,17 +15,12 @@
 package com.huawei.cloud.fixtures;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import jakarta.json.JsonArray;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 
 import java.net.URI;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static io.restassured.http.ContentType.JSON;
-import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.boot.BootServicesExtension.PARTICIPANT_ID;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
@@ -59,6 +54,7 @@ public class HuaweiParticipant extends Participant {
                 put("web.http.public.port", String.valueOf(getFreePort()));
                 put("edc.dsp.callback.address", protocolEndpoint.getUrl().toString());
                 put("edc.connector.name", name);
+                put("edc.component.id", "connector-test");
                 put("edc.dataplane.token.validation.endpoint", "http://token-validation.com");
                 put("edc.dpf.selector.url", "http://does-this-matter.com");
                 put("edc.huawei.iam.endpoint", IAM_OTC_CLOUD_URL);
@@ -66,25 +62,6 @@ public class HuaweiParticipant extends Participant {
                 put("edc.transfer.proxy.token.signer.privatekey.alias", "privatekey");
             }
         };
-    }
-
-    public JsonArray getPolicies() {
-
-        AtomicReference<JsonArray> array = new AtomicReference<>();
-        await().atMost(TIMEOUT).untilAsserted(() -> {
-            var response = managementEndpoint.baseRequest()
-                    .contentType(JSON)
-                    .when()
-                    .post("/v2/policydefinitions/request")
-                    .then()
-                    .log().ifError()
-                    .statusCode(200)
-                    .extract().body().asString();
-
-            array.set(objectMapper.readValue(response, JsonArray.class));
-        });
-
-        return array.get();
     }
 
     public static final class Builder extends Participant.Builder<HuaweiParticipant, Builder> {

--- a/e2e-tests/src/test/java/com/huawei/cloud/fixtures/HuaweiParticipant.java
+++ b/e2e-tests/src/test/java/com/huawei/cloud/fixtures/HuaweiParticipant.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+
 import static org.eclipse.edc.boot.BootServicesExtension.PARTICIPANT_ID;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 

--- a/e2e-tests/src/test/java/com/huawei/cloud/tests/ObsTransferEndToEndTest.java
+++ b/e2e-tests/src/test/java/com/huawei/cloud/tests/ObsTransferEndToEndTest.java
@@ -25,6 +25,7 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowStartMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowResponseMessageTransformer;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EdcClassRuntimesExtension;
 import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
 import org.eclipse.edc.spi.result.Failure;
@@ -58,7 +59,7 @@ import static org.eclipse.edc.junit.testfixtures.TestUtils.getFileFromResourceNa
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 @Testcontainers
-//@EndToEndTest
+@EndToEndTest
 public class ObsTransferEndToEndTest {
     public static final String MINIO_DOCKER_IMAGE = "bitnami/minio";
     public static final int MINIO_CONTAINER_PORT = 9000;

--- a/e2e-tests/src/test/java/com/huawei/cloud/tests/ObsTransferEndToEndTest.java
+++ b/e2e-tests/src/test/java/com/huawei/cloud/tests/ObsTransferEndToEndTest.java
@@ -25,7 +25,6 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.api.signaling.transform.from.JsonObjectFromDataFlowStartMessageTransformer;
 import org.eclipse.edc.connector.api.signaling.transform.to.JsonObjectToDataFlowResponseMessageTransformer;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
-import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EdcClassRuntimesExtension;
 import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
 import org.eclipse.edc.spi.result.Failure;

--- a/extensions/control-plane/provision-obs/src/main/java/com/huawei/cloud/provision/obs/ObsResourceDefinition.java
+++ b/extensions/control-plane/provision-obs/src/main/java/com/huawei/cloud/provision/obs/ObsResourceDefinition.java
@@ -14,10 +14,15 @@
 
 package com.huawei.cloud.provision.obs;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ResourceDefinition;
 
 import java.util.Objects;
 
+@JsonTypeName("dataspaceconnector:obsresourcedefinition")
+@JsonDeserialize(builder = ObsResourceDefinition.Builder.class)
 public class ObsResourceDefinition extends ResourceDefinition {
 
     private String endpoint;
@@ -42,6 +47,7 @@ public class ObsResourceDefinition extends ResourceDefinition {
                 .endpoint(endpoint);
     }
 
+    @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends ResourceDefinition.Builder<ObsResourceDefinition, Builder> {
 
         private Builder() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 #
 
 group=com.huawei.cloud
-version=0.8.2-SNAPSHOT
+version=0.11.0-SNAPSHOT
 # configure the build:
 # used for publishing artifacts and plugins
 hcScmConnection=scm:git:git@github.com:huawei-dataspace-components/components.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ format.version = "1.1"
 [versions]
 awaitility = "4.2.2"
 bouncyCastle-jdk18on = "1.78.1"
-edc = "0.8.2-SNAPSHOT"
+edc = "0.10.0-SNAPSHOT"
 failsafe = "3.3.2"
 httpMockServer = "5.15.0"
 jakarta-json = "2.0.1"
@@ -41,16 +41,16 @@ edc-core-catalog = { module = "org.eclipse.edc:catalog-core", version.ref = "edc
 edc-core-jersey = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
 edc-core-jetty = { module = "org.eclipse.edc:jetty-core", version.ref = "edc" }
 edc-core-jwt = { module = "org.eclipse.edc:jwt-core", version.ref = "edc" }
+edc-core-token = { module = "org.eclipse.edc:token-core", version.ref = "edc" }
 edc-dpf-framework = { module = "org.eclipse.edc:data-plane-framework", version.ref = "edc" }
 edc-dpf-core = { module = "org.eclipse.edc:data-plane-core", version.ref = "edc" }
-edc-dpf-transfer = { module = "org.eclipse.edc:transfer-data-plane-signaling", version.ref = "edc" }
 edc-dpf-selector-core = { module = "org.eclipse.edc:data-plane-selector-core", version.ref = "edc" }
 edc-dpf-selector-spi = { module = "org.eclipse.edc:data-plane-selector-spi", version.ref = "edc" }
 edc-dpf-selector-api = { module = "org.eclipse.edc:data-plane-selector-api", version.ref = "edc" }
 edc-dpf-client = { module = "org.eclipse.edc:data-plane-client", version.ref = "edc" }
 edc-dpf-http = { module = "org.eclipse.edc:data-plane-http", version.ref = "edc" }
 edc-dpf-http-oauth2 = { module = "org.eclipse.edc:data-plane-http-oauth2", version.ref = "edc" }
-edc-dpf-api = { module = "org.eclipse.edc:data-plane-control-api", version.ref = "edc" }
+edc-dpf-iam = { module = "org.eclipse.edc:data-plane-iam", version.ref = "edc" }
 edc-dpf-util = { module = "org.eclipse.edc:data-plane-util", version.ref = "edc" }
 edc-dpf-self-registration = { module = "org.eclipse.edc:data-plane-self-registration", version.ref = "edc" }
 edc-ext-azure-cosmos-core = { module = "org.eclipse.edc:azure-cosmos-core", version.ref = "edc" }
@@ -97,6 +97,13 @@ edc-lib-util = { module = "org.eclipse.edc:util-lib", version.ref = "edc" }
 # Control Plane implementations
 edc-controlplane-callback-dispatcher-event = { module = "org.eclipse.edc:callback-event-dispatcher", version.ref = "edc" }
 edc-controlplane-callback-dispatcher-http = { module = "org.eclipse.edc:callback-http-dispatcher", version.ref = "edc" }
+edc-controlplane-edr-core-store = { module= "org.eclipse.edc:edr-store-core", version.ref = "edc" }
+
+# Data-Plane Signaling
+edc-dpf-signaling = { module = "org.eclipse.edc:transfer-data-plane-signaling", version.ref = "edc" }
+edc-dpf-signaling-api = { module = "org.eclipse.edc:data-plane-signaling-api", version.ref = "edc" }
+edc-dpf-public-api = { module = "org.eclipse.edc:data-plane-public-api-v2", version.ref = "edc" }
+
 
 # third-party deps
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
@@ -119,7 +126,7 @@ huawei-iam = { module = "com.huaweicloud.sdk:huaweicloud-sdk-iam", version.ref =
 huawei-dws-jdbc = { module = "com.huaweicloud.dws:huaweicloud-dws-jdbc", version.ref = "huawei-dws" }
 
 [bundles]
-edc-dpf = ["edc.dpf-transfer", "edc.dpf-selector-core", "edc.spi-dataplane-selector"]
+edc-dpf = ["edc.dpf-signaling","edc.dpf-signaling-api","edc.dpf-public-api", "edc.dpf-selector-core", "edc.spi-dataplane-selector"]
 
 [plugins]
 shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,7 +92,7 @@ edc-transfer-httppull-receiver = { module = "org.eclipse.edc:transfer-pull-http-
 edc-transfer-httppull-receiver-dynamic = { module = "org.eclipse.edc:transfer-pull-http-dynamic-receiver", version.ref = "edc" }
 edc-util = { module = "org.eclipse.edc:util", version.ref = "edc" }
 edc-testfixtures-managementapi = { module = "org.eclipse.edc:management-api-test-fixtures", version.ref = "edc" }
-edc-lib-util = { module = "org.eclipse.edc:util-lib", version.ref = "edc" }
+
 
 # Control Plane implementations
 edc-controlplane-callback-dispatcher-event = { module = "org.eclipse.edc:callback-event-dispatcher", version.ref = "edc" }
@@ -103,6 +103,14 @@ edc-controlplane-edr-core-store = { module= "org.eclipse.edc:edr-store-core", ve
 edc-dpf-signaling = { module = "org.eclipse.edc:transfer-data-plane-signaling", version.ref = "edc" }
 edc-dpf-signaling-api = { module = "org.eclipse.edc:data-plane-signaling-api", version.ref = "edc" }
 edc-dpf-public-api = { module = "org.eclipse.edc:data-plane-public-api-v2", version.ref = "edc" }
+
+
+# edc-transform
+edc-transform-dpf-signaling = { module = "org.eclipse.edc:data-plane-signaling-transform", version.ref = "edc" }
+
+# edc-lib
+edc-lib-util = { module = "org.eclipse.edc:util-lib", version.ref = "edc" }
+edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "edc" }
 
 
 # third-party deps

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ format.version = "1.1"
 [versions]
 awaitility = "4.2.2"
 bouncyCastle-jdk18on = "1.78.1"
-edc = "0.10.0-SNAPSHOT"
+edc = "0.11.0-SNAPSHOT"
 failsafe = "3.3.2"
 httpMockServer = "5.15.0"
 jakarta-json = "2.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,20 +3,20 @@ format.version = "1.1"
 
 [versions]
 awaitility = "4.2.2"
-bouncyCastle-jdk18on = "1.78.1"
+bouncyCastle-jdk18on = "1.79"
 edc = "0.11.0-SNAPSHOT"
 failsafe = "3.3.2"
 httpMockServer = "5.15.0"
 jakarta-json = "2.0.1"
 junit = "5.11.2"
 mockito = "5.2.0"
-nimbus = "9.41.2"
+nimbus = "9.45"
 restAssured = "5.4.0"
 rsApi = "4.0.0"
-testcontainers = "1.20.2"
+testcontainers = "1.20.3"
 huawei-obs = "3.24.9"
-huawei-iam = "3.1.115"
-huawei-dws = "8.3.1.200-200"
+huawei-iam = "3.1.120"
+huawei-dws = "8.5.0-200"
 
 [libraries]
 

--- a/launchers/e2e-test/build.gradle.kts
+++ b/launchers/e2e-test/build.gradle.kts
@@ -22,35 +22,27 @@ plugins {
 
 dependencies {
 
+
     runtimeOnly(project(":extensions:control-plane:provision-obs"))
     runtimeOnly(project(":extensions:data-plane:data-plane-obs"))
-    runtimeOnly(libs.edc.core.controlplane)
-    runtimeOnly(libs.edc.core.dataplane)
+
     runtimeOnly(libs.edc.core.connector)
-    runtimeOnly(libs.edc.config.filesystem)
-    runtimeOnly(libs.edc.auth.tokenbased)
-
-    runtimeOnly(libs.edc.api.management)
-    runtimeOnly(libs.edc.api.controlplane)
-    runtimeOnly(libs.edc.dpf.api)
-    runtimeOnly(libs.edc.dpf.selector.api)
-    runtimeOnly(libs.edc.api.management.config)
-    runtimeOnly(libs.edc.api.observability)
-    runtimeOnly(libs.edc.dsp)
-    runtimeOnly(libs.edc.spi.jwt)
-    runtimeOnly(libs.bundles.edc.dpf)
-    runtimeOnly(libs.edc.iam.mock)
-    runtimeOnly(libs.edc.ext.http)
-    runtimeOnly(libs.edc.controlplane.callback.dispatcher.event)
-    runtimeOnly(libs.edc.controlplane.callback.dispatcher.http)
-    runtimeOnly(libs.edc.core.controlplane.apiclient)
-    runtimeOnly(libs.edc.transfer.dataplane)
-    runtimeOnly(libs.edc.dpf.self.registration)
+    runtimeOnly(libs.edc.core.dataplane)
     runtimeOnly(libs.edc.control.api.configuration)
-
-    implementation(libs.edc.spi.core)
+    runtimeOnly(libs.edc.core.controlplane.apiclient)
+    runtimeOnly(libs.edc.dpf.iam)
+    runtimeOnly(libs.edc.dpf.public.api)
+    runtimeOnly(libs.edc.ext.http)
+    runtimeOnly(libs.edc.jsonld)
+    runtimeOnly(libs.edc.core.token)
     runtimeOnly(libs.edc.core.controlplane)
-    testImplementation(libs.edc.junit)
+    runtimeOnly(libs.edc.dsp)
+    runtimeOnly(libs.edc.iam.mock)
+    runtimeOnly(libs.edc.api.management)
+    runtimeOnly(libs.edc.controlplane.edr.core.store)
+    runtimeOnly(libs.edc.dpf.self.registration)
+    runtimeOnly(libs.bundles.edc.dpf)
+    runtimeOnly(libs.edc.api.controlplane)
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {

--- a/launchers/huawei-cloud-runtime/build.gradle.kts
+++ b/launchers/huawei-cloud-runtime/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
     runtimeOnly(libs.edc.api.management)
     runtimeOnly(libs.edc.api.controlplane)
-    runtimeOnly(libs.edc.dpf.api)
+    runtimeOnly(libs.edc.dpf.iam)
     runtimeOnly(libs.edc.dpf.selector.api)
     runtimeOnly(libs.edc.api.management.config)
     runtimeOnly(libs.edc.api.observability)
@@ -46,6 +46,7 @@ dependencies {
     runtimeOnly(libs.edc.controlplane.callback.dispatcher.event)
     runtimeOnly(libs.edc.controlplane.callback.dispatcher.http)
     runtimeOnly(libs.edc.core.controlplane.apiclient)
+    runtimeOnly(libs.edc.controlplane.edr.core.store)
 
 
     implementation(libs.edc.spi.core)


### PR DESCRIPTION
## What this PR changes/adds

This PR bumps the EDC-Version to 0.11.0-Snapshot.
This PR adapts the Tests of the Repo to the new Version.
This PR fixes a bug for using Provisioning with Postgresql

## Why it does that

Update EDC-Version

## Further notes

---

## Linked Issue(s)

Closes #69 