### PR TITLE
fix: add write permission for prepare-workflow action #107

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,5 +1,8 @@
 name: Prepare Release
 
+permissions:
+  actions: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What this PR changes/adds

Adds write permission for prepare-release workflow

## Why it does that

BugFix

## Linked Issue(s)

Closes #107 