### PR TITLE
fix: Revert "chore(deps): bump edc from 0.11.0-SNAPSHOT to 0.11.0-20241210…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 awaitility = "4.2.2"
-edc = "0.11.0-20241210-SNAPSHOT"
+edc = "0.11.0-SNAPSHOT"
 failsafe = "3.3.2"
 junit = "5.11.3"
 restAssured = "5.4.0"


### PR DESCRIPTION
…-SNAPSHOT (#112)"

This reverts commit b016985622e0b9c401d090073e03d4618741bd3f.

## What this PR changes/adds

_Briefly describe WHAT your pr changes, which features it adds/modifies._

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
