### PR TITLE
build: ignore edc upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,4 @@ updates:
       - "dependencies"
       - "java"
     ignore:
-      - dependency-name: "org.eclipse.edc:edc-versions"
-
+      - dependency-name: "org.eclipse.edc:*"


### PR DESCRIPTION
## What this PR changes/adds

Apparently the command sent to the bot was not enough, so let's just configure dependabot to exclude edc core updates.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
