### PR TITLE
fix: adapt gradle.properties to edc repository #130

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,9 +12,9 @@
 #
 #
 
-group=com.huawei.cloud
+group=org.eclipse.edc.azure
 version=0.12.0-SNAPSHOT
 # configure the build:
 # used for publishing artifacts and plugins
-hcScmConnection=scm:git:git@github.com:huawei-dataspace-components/components.git
-hcScmUrl=https://github.com/Huawei-Cloud-Components/components.git
+hcScmConnection=scm:git:git@github.com:eclipse-edc/Technology-HuaweiCloud.git
+hcScmUrl=https://github.com/eclipse-edc/Technology-HuaweiCloud.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 #
 #
 
-group=org.eclipse.edc.azure
+group=org.eclipse.edc.huawei
 version=0.12.0-SNAPSHOT
 # configure the build:
 # used for publishing artifacts and plugins


### PR DESCRIPTION
## What this PR changes/adds

Adapt the gradle properties to the EDC-Environment. Change URLs to correct Repo and change group Name.

## Why it does that

Make Repo possible to publish

## Linked Issue(s)

Closes #130 