### PR TITLE
fix: set correct group and links for publishing release/0.12.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,9 +12,9 @@
 #
 #
 
-group=com.huawei.cloud
+group=org.eclipse.edc.huawei
 version=0.12.0
 # configure the build:
 # used for publishing artifacts and plugins
-hcScmConnection=scm:git:git@github.com:huawei-dataspace-components/components.git
-hcScmUrl=https://github.com/Huawei-Cloud-Components/components.git
+hcScmConnection=scm:git:git@github.com:eclipse-edc/Technology-HuaweiCloud.git
+hcScmUrl=https://github.com/eclipse-edc/Technology-HuaweiCloud.git


### PR DESCRIPTION
## What this PR changes/adds

Set correct Package and Urls for publishing

## Why it does that

Fixing Release

## Further notes

I will open another issue and MR for the main branch.

## Who will sponsor this feature?

@ndr-brt @mspiekermann 

## Linked Issue(s)

Closes No issue existing
