### PR TITLE
build: pass group id

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ allprojects {
         pom {
             scmUrl.set(hcScmConnection)
             scmConnection.set(hcScmConnection)
-            developerId.set("Atul Shrivijay Atavale")
+            groupId = project.group.toString()
         }
     }
 


### PR DESCRIPTION
## What this PR changes/adds

pass the group id specified in gradle.properties to the build task

## Why it does that

publish the artifacts under the right groupId (was `org.eclipse.edc`, now `org.eclipse.edc.huawei`)

## Further notes

closes #169 