### PR TITLE
fix: set path to new maven repo, pull groupid #190

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ allprojects {
         pom {
             scmUrl.set(hcScmConnection)
             scmConnection.set(hcScmConnection)
-            developerId.set("Atul Shrivijay Atavale")
+            groupId = project.group.toString()
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 #
 
 group=org.eclipse.edc.huawei
-version=0.13.0-SNAPSHOT
+version=0.13.0
 # configure the build:
 # used for publishing artifacts and plugins
 hcScmConnection=scm:git:git@github.com:eclipse-edc/Technology-HuaweiCloud.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 awaitility = "4.2.2"
-edc = "0.13.0-SNAPSHOT"
+edc = "0.13.0"
 failsafe = "3.3.2"
 junit = "5.12.2"
 restAssured = "5.5.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,25 +12,13 @@
  *
  */
 
-// this is needed to have access to snapshot builds of plugins
 pluginManagement {
     repositories {
-        mavenLocal()
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
         mavenCentral()
         gradlePluginPortal()
-    }
-}
-
-dependencyResolutionManagement {
-    repositories {
-        mavenLocal()
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
-        mavenCentral()
     }
 }
 


### PR DESCRIPTION
## What this PR changes/adds

Fix Release to Maven Repo to newest Url.

## Why it does that

Credentials and target are not synced rn.

## Further notes

Credentials are changed while the release Branch was prepared but not executed.


## Who will sponsor this feature?

@ndr-brt 
@mspiekermann 


## Linked Issue(s)

Closes #190
